### PR TITLE
Inconsistency in licensing manager role

### DIFF
--- a/contracts/lib/AccessControl.sol
+++ b/contracts/lib/AccessControl.sol
@@ -30,6 +30,4 @@ library AccessControl {
     // Role that can execute Hooks
     bytes32 public constant HOOK_CALLER_ROLE = keccak256("HOOK_CALLER_ROLE");
 
-    // Role to set legal terms in TermsRepository
-    bytes32 public constant LICENSING_MANAGER = keccak256("LICENSING_MANAGER");
 }

--- a/contracts/modules/licensing/LicensingFrameworkRepo.sol
+++ b/contracts/modules/licensing/LicensingFrameworkRepo.sol
@@ -47,7 +47,7 @@ contract LicensingFrameworkRepo is AccessControlled, Multicall {
     /// @dev this is an admin only function, and can only be called by the
     /// licensing manager role
     /// @param input_ the input parameters for the framework
-    function addFramework(Licensing.SetFramework calldata input_) external onlyRole(AccessControl.LICENSING_MANAGER) {
+    function addFramework(Licensing.SetFramework calldata input_) external onlyRole(AccessControl.LICENSING_MANAGER_ROLE) {
         FrameworkStorage storage framework = _frameworks[input_.id];
         if (framework.paramTags.length() > 0) {
             revert Errors.LicensingFrameworkRepo_FrameworkAlreadyAdded();

--- a/script/foundry/deployment/Main.s.sol
+++ b/script/foundry/deployment/Main.s.sol
@@ -298,10 +298,6 @@ contract Main is Script, BroadcastManager, JsonDeploymentHandler, ProxyHelper {
             admin
         );
         accessControlSingleton.grantRole(
-            AccessControl.LICENSING_MANAGER,
-            admin
-        );
-        accessControlSingleton.grantRole(
             AccessControl.IPORG_CREATOR_ROLE,
             admin
         );

--- a/test/foundry/e2e/e2e.t.sol
+++ b/test/foundry/e2e/e2e.t.sol
@@ -85,7 +85,7 @@ contract E2ETest is IE2ETest, BaseTest {
     function setUp() public virtual override {
         super.setUp();
         _grantRole(vm, AccessControl.RELATIONSHIP_MANAGER_ROLE, admin);
-        _grantRole(vm, AccessControl.LICENSING_MANAGER, admin);
+        _grantRole(vm, AccessControl.LICENSING_MANAGER_ROLE, admin);
         _grantRole(
             vm,
             AccessControl.HOOK_CALLER_ROLE,

--- a/test/foundry/modules/licensing/LicensingFrameworkRepo.t.sol
+++ b/test/foundry/modules/licensing/LicensingFrameworkRepo.t.sol
@@ -22,7 +22,7 @@ contract LicensingFrameworkRepoTest is Test, AccessControlHelper {
 
     function setUp() public {
         _setupAccessControl();
-        _grantRole(vm, AccessControl.LICENSING_MANAGER, admin);
+        _grantRole(vm, AccessControl.LICENSING_MANAGER_ROLE, admin);
         repo = new LicensingFrameworkRepo(address(accessControl));
     }
 
@@ -68,7 +68,7 @@ contract LicensingFrameworkRepoTest is Test, AccessControlHelper {
         vm.expectRevert(
             abi.encodeWithSelector(
                 Errors.MissingRole.selector,
-                AccessControl.LICENSING_MANAGER,
+                AccessControl.LICENSING_MANAGER_ROLE,
                 address(this)
             )
         );

--- a/test/foundry/utils/BaseTest.sol
+++ b/test/foundry/utils/BaseTest.sol
@@ -77,7 +77,7 @@ contract BaseTest is BaseTestUtils, ProxyHelper, AccessControlHelper {
 
         // Create Licensing contracts
         licensingFrameworkRepo = new LicensingFrameworkRepo(address(accessControl));
-        _grantRole(vm, AccessControl.LICENSING_MANAGER, licensingManager);
+        _grantRole(vm, AccessControl.LICENSING_MANAGER_ROLE, licensingManager);
 
         licenseRegistry = new LicenseRegistry(
             address(registry),


### PR DESCRIPTION
Due probably to merge shenanigans, we defined both:
```
LICENSING_MANAGER_ROLE
LICENSING_MANAGER
```
as AccessControl roles.